### PR TITLE
Add semicolon to cache initialization

### DIFF
--- a/c_main.lua
+++ b/c_main.lua
@@ -10,7 +10,7 @@ sx, sy = guiGetScreenSize()
 zoom = 1920/sx
 zoom = math.min(zoom, 1.3)
 
-cache = {}
+cache = {};
 
 function toggleHUDComponents(state)
     setPlayerHudComponentVisible('all', state)


### PR DESCRIPTION
Append a semicolon to the cache initialization in c_main.lua (cache = {} -> cache = {};). This is a tiny style change with no functional impact, aligning the line with the project's statement terminator convention.